### PR TITLE
엔티티 생성

### DIFF
--- a/src/main/java/gdsc/comunity/CommunityApplication.java
+++ b/src/main/java/gdsc/comunity/CommunityApplication.java
@@ -2,12 +2,12 @@ package gdsc.comunity;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CommunityApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(CommunityApplication.class, args);
 	}
-
 }

--- a/src/main/java/gdsc/comunity/entity/channel/Channel.java
+++ b/src/main/java/gdsc/comunity/entity/channel/Channel.java
@@ -1,0 +1,47 @@
+package gdsc.comunity.entity.channel;
+
+
+import gdsc.comunity.entity.common.BaseTimeEntity;
+import gdsc.comunity.entity.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Channel extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+/*
+    fixme:
+    현재 채널마다 음성채팅방1개, 채팅방1개를 가지고 있습니다. 그냥 Channel id로 식별이 가능해서 필요없을 거 같아요.
+    필요없다고 생각되시면 suggest로 해당 사항 삭제해주시면 됩니다.
+
+    @Column(unique = true)
+    private Long chatRoomId;
+
+    @Column(unique = true)
+    private Long voiceRoomId;
+*/
+
+    @ManyToOne
+    @JoinColumn(name = "manager_id")
+    private User manager;
+
+    @Builder
+    private Channel(User manager) {
+        this.manager = manager;
+    }
+
+}

--- a/src/main/java/gdsc/comunity/entity/channel/Channel.java
+++ b/src/main/java/gdsc/comunity/entity/channel/Channel.java
@@ -5,6 +5,7 @@ import gdsc.comunity.entity.common.BaseTimeEntity;
 import gdsc.comunity.entity.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -35,7 +36,7 @@ public class Channel extends BaseTimeEntity {
     private Long voiceRoomId;
 */
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id")
     private User manager;
 

--- a/src/main/java/gdsc/comunity/entity/channel/Schedule.java
+++ b/src/main/java/gdsc/comunity/entity/channel/Schedule.java
@@ -1,0 +1,52 @@
+package gdsc.comunity.entity.channel;
+
+import gdsc.comunity.entity.common.BaseTimeEntity;
+import gdsc.comunity.entity.user.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Schedule extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private User author;
+
+    @Builder
+    private Schedule(LocalDate date, String title, String content, Channel channel, User author) {
+        this.date = date;
+        this.title = title;
+        this.content = content;
+        this.channel = channel;
+        this.author = author;
+    }
+}

--- a/src/main/java/gdsc/comunity/entity/chat/ChatLog.java
+++ b/src/main/java/gdsc/comunity/entity/chat/ChatLog.java
@@ -4,6 +4,7 @@ import gdsc.comunity.entity.channel.Channel;
 import gdsc.comunity.entity.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,7 +28,7 @@ public class ChatLog extends BaseTimeEntity {
     @Column(nullable = false, length = 1000)
     private String content;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
 

--- a/src/main/java/gdsc/comunity/entity/chat/ChatLog.java
+++ b/src/main/java/gdsc/comunity/entity/chat/ChatLog.java
@@ -1,0 +1,40 @@
+package gdsc.comunity.entity.chat;
+
+import gdsc.comunity.entity.channel.Channel;
+import gdsc.comunity.entity.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ChatLog extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long senderId;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
+    @Builder
+    private ChatLog(Long senderId, String content, Channel channel) {
+        this.senderId = senderId;
+        this.content = content;
+        this.channel = channel;
+    }
+}

--- a/src/main/java/gdsc/comunity/entity/common/BaseTimeEntity.java
+++ b/src/main/java/gdsc/comunity/entity/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package gdsc.comunity.entity.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+}

--- a/src/main/java/gdsc/comunity/entity/user/Provider.java
+++ b/src/main/java/gdsc/comunity/entity/user/Provider.java
@@ -1,0 +1,5 @@
+package gdsc.comunity.entity.user;
+
+public enum Provider {
+    NAVER, KAKAO, GOOGLE
+}

--- a/src/main/java/gdsc/comunity/entity/user/User.java
+++ b/src/main/java/gdsc/comunity/entity/user/User.java
@@ -1,0 +1,45 @@
+package gdsc.comunity.entity.user;
+
+import gdsc.comunity.entity.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+@Entity
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Provider provider;
+
+    @Column(nullable = false)
+    private String providerId;
+
+    private String profileImageUrl;
+
+    @Builder
+    private User(String email, Provider provider, String providerId, String profileImageUrl) {
+        this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/gdsc/comunity/entity/user/UserChannel.java
+++ b/src/main/java/gdsc/comunity/entity/user/UserChannel.java
@@ -1,0 +1,45 @@
+package gdsc.comunity.entity.user;
+
+import gdsc.comunity.entity.channel.Channel;
+import gdsc.comunity.entity.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class UserChannel extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
+    @Builder
+    private UserChannel(String nickname, User user, Channel channel) {
+        this.nickname = nickname;
+        this.user = user;
+        this.channel = channel;
+    }
+}
+
+
+

--- a/src/main/java/gdsc/comunity/entity/user/UserChannel.java
+++ b/src/main/java/gdsc/comunity/entity/user/UserChannel.java
@@ -4,6 +4,7 @@ import gdsc.comunity.entity.channel.Channel;
 import gdsc.comunity.entity.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class UserChannel extends BaseTimeEntity {
     @Column(nullable = false)
     private String nickname;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
 

--- a/src/main/java/gdsc/comunity/repository/channel/ChannelRepository.java
+++ b/src/main/java/gdsc/comunity/repository/channel/ChannelRepository.java
@@ -1,0 +1,7 @@
+package gdsc.comunity.repository.channel;
+
+import gdsc.comunity.entity.channel.Channel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelRepository extends JpaRepository<Channel, Long> {
+}

--- a/src/main/java/gdsc/comunity/repository/channel/ScheduleRepository.java
+++ b/src/main/java/gdsc/comunity/repository/channel/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package gdsc.comunity.repository.channel;
+
+import gdsc.comunity.entity.channel.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/gdsc/comunity/repository/chat/ChatLogRepository.java
+++ b/src/main/java/gdsc/comunity/repository/chat/ChatLogRepository.java
@@ -1,0 +1,7 @@
+package gdsc.comunity.repository.chat;
+
+import gdsc.comunity.entity.chat.ChatLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
+}

--- a/src/main/java/gdsc/comunity/repository/user/UserChannelRepository.java
+++ b/src/main/java/gdsc/comunity/repository/user/UserChannelRepository.java
@@ -1,0 +1,8 @@
+package gdsc.comunity.repository.user;
+
+
+import gdsc.comunity.entity.user.UserChannel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserChannelRepository extends JpaRepository<UserChannel, Long> {
+}

--- a/src/main/java/gdsc/comunity/repository/user/UserRepository.java
+++ b/src/main/java/gdsc/comunity/repository/user/UserRepository.java
@@ -1,0 +1,7 @@
+package gdsc.comunity.repository.user;
+
+import gdsc.comunity.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=community

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: "jdbc:h2:mem:community;MODE=PostgreSQL"
+    username: "sa"
+    password: ""
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+logging.level:
+  org.hibernate:
+    orm.jdbc.bind: trace
+    SQL: debug


### PR DESCRIPTION
### 내용
- BaseTimeEntity로 생성시간, 수정시간을 관리합니다
- FetchType 전부 Lazy로 구성했습니다
- 연관관계는 전부 단방향으로 구성했습니다.

### 확인사항
현재 스펙에서 Channel Entity에 chatRoom과 voiceRoom의 id를 관리할 필요성이 없다고 느껴 제거했습니다.
확인하시면, suggestion 남겨주세요