### PR TITLE
인증/인가 구현 #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### env ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	//Postgre SQL
 	implementation 'org.postgresql:postgresql'
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,27 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	//Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//JSON
+	implementation 'com.google.code.gson:gson'
+
+	//WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	//Postgre SQL
+	implementation 'org.postgresql:postgresql'
 }
 
 tasks.named('test') {

--- a/src/main/java/gdsc/comunity/annotation/UserId.java
+++ b/src/main/java/gdsc/comunity/annotation/UserId.java
@@ -1,0 +1,13 @@
+package gdsc.comunity.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/gdsc/comunity/controller/AuthController.java
+++ b/src/main/java/gdsc/comunity/controller/AuthController.java
@@ -27,8 +27,7 @@ public class AuthController {
         //1. refresh token 유효성 검증
         authService.validateRefreshToken(refreshTokenDto.refreshToken());
 
-        //2. 새로운 토큰 발급하고 기존 redis 삭제
-        //3. 리턴
-        return ResponseEntity.ok(authService.refreshNewTokens(refreshTokenDto.refreshToken()));
+        JwtTokensDto newTokens = authService.refreshNewTokens(refreshTokenDto.refreshToken());
+        return ResponseEntity.ok(newTokens);
     }
 }

--- a/src/main/java/gdsc/comunity/controller/AuthController.java
+++ b/src/main/java/gdsc/comunity/controller/AuthController.java
@@ -1,0 +1,34 @@
+package gdsc.comunity.controller;
+
+import gdsc.comunity.dto.JwtTokensDto;
+import gdsc.comunity.dto.RefreshTokenDto;
+import gdsc.comunity.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<JwtTokensDto> refreshNewTokens(
+            @RequestBody RefreshTokenDto refreshTokenDto
+    ) {
+        //1. refresh token 유효성 검증
+        authService.validateRefreshToken(refreshTokenDto.refreshToken());
+
+        //2. 새로운 토큰 발급하고 기존 redis 삭제
+        //3. 리턴
+        return ResponseEntity.ok(authService.refreshNewTokens(refreshTokenDto.refreshToken()));
+    }
+}

--- a/src/main/java/gdsc/comunity/controller/OAuthController.java
+++ b/src/main/java/gdsc/comunity/controller/OAuthController.java
@@ -26,11 +26,9 @@ public class OAuthController {
     ) {
         //1. 해당 코드로 구글에게 토큰을 요청
         String tokenByGoogle = oAuthGoogleService.getAccessToken(code);
-        log.info("tokenByGoogle : {}", tokenByGoogle);
 
         //2. 토큰을 받아서 유저 정보를 가져옴
         Map<String, String> userInfo = oAuthGoogleService.getUserInfoByAccessToken(tokenByGoogle);
-        log.info("userInfo : {}", userInfo);
 
         //3. 유저 정보를 토대로 회원가입 or 로그인
         JwtTokensDto jwtDto = oAuthGoogleService.loginOrRegister(userInfo);

--- a/src/main/java/gdsc/comunity/controller/OAuthController.java
+++ b/src/main/java/gdsc/comunity/controller/OAuthController.java
@@ -1,5 +1,6 @@
 package gdsc.comunity.controller;
 
+import gdsc.comunity.dto.GoogleUserInfo;
 import gdsc.comunity.dto.JwtTokensDto;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -10,29 +11,29 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import gdsc.comunity.service.OAuthService;
+import gdsc.comunity.service.OAuthGoogleService;
 
 @Slf4j
 @RestController
 @RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class OAuthController {
-    private final OAuthService oAuthService;
+    private final OAuthGoogleService oAuthGoogleService;
 
     @GetMapping("/login/google/callback")
     public ResponseEntity<?> loginByGoogleCallback(
             @RequestParam("code") String code
     ) {
         //1. 해당 코드로 구글에게 토큰을 요청
-        String tokenByGoogle = oAuthService.getAccessToken(code);
+        String tokenByGoogle = oAuthGoogleService.getAccessToken(code);
         log.info("tokenByGoogle : {}", tokenByGoogle);
 
         //2. 토큰을 받아서 유저 정보를 가져옴
-        Map<String, String> userInfo = oAuthService.getUserInfoByAccessToken(tokenByGoogle);
+        Map<String, String> userInfo = oAuthGoogleService.getUserInfoByAccessToken(tokenByGoogle);
         log.info("userInfo : {}", userInfo);
 
         //3. 유저 정보를 토대로 회원가입 or 로그인
-        JwtTokensDto jwtDto = oAuthService.loginOrRegister(userInfo);
+        JwtTokensDto jwtDto = oAuthGoogleService.loginOrRegister(userInfo);
         return new ResponseEntity<>(jwtDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/gdsc/comunity/controller/OAuthController.java
+++ b/src/main/java/gdsc/comunity/controller/OAuthController.java
@@ -1,0 +1,38 @@
+package gdsc.comunity.controller;
+
+import gdsc.comunity.dto.JwtTokensDto;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import gdsc.comunity.service.OAuthService;
+
+@Slf4j
+@RestController
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+    private final OAuthService oAuthService;
+
+    @GetMapping("/login/google/callback")
+    public ResponseEntity<?> loginByGoogleCallback(
+            @RequestParam("code") String code
+    ) {
+        //1. 해당 코드로 구글에게 토큰을 요청
+        String tokenByGoogle = oAuthService.getAccessToken(code);
+        log.info("tokenByGoogle : {}", tokenByGoogle);
+
+        //2. 토큰을 받아서 유저 정보를 가져옴
+        Map<String, String> userInfo = oAuthService.getUserInfoByAccessToken(tokenByGoogle);
+        log.info("userInfo : {}", userInfo);
+
+        //3. 유저 정보를 토대로 회원가입 or 로그인
+        JwtTokensDto jwtDto = oAuthService.loginOrRegister(userInfo);
+        return new ResponseEntity<>(jwtDto, HttpStatus.OK);
+    }
+}

--- a/src/main/java/gdsc/comunity/dto/JwtTokensDto.java
+++ b/src/main/java/gdsc/comunity/dto/JwtTokensDto.java
@@ -1,0 +1,10 @@
+package gdsc.comunity.dto;
+
+import lombok.Builder;
+
+@Builder
+public record JwtTokensDto(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/gdsc/comunity/dto/RefreshTokenDto.java
+++ b/src/main/java/gdsc/comunity/dto/RefreshTokenDto.java
@@ -1,0 +1,9 @@
+package gdsc.comunity.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RefreshTokenDto(
+        String refreshToken
+) {
+}

--- a/src/main/java/gdsc/comunity/exception/CustomException.java
+++ b/src/main/java/gdsc/comunity/exception/CustomException.java
@@ -1,7 +1,8 @@
 package gdsc.comunity.exception;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
+@Getter
 @RequiredArgsConstructor
 public class CustomException extends RuntimeException{
     private final ErrorCode errorCode;

--- a/src/main/java/gdsc/comunity/exception/CustomException.java
+++ b/src/main/java/gdsc/comunity/exception/CustomException.java
@@ -1,0 +1,8 @@
+package gdsc.comunity.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-    INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+    INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    OAUTH_SERVER_ERROR(40300, HttpStatus.BAD_GATEWAY, "OAuth 서버 에러입니다. ");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
-    LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -7,10 +7,14 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+    //401
     LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN_ERROR(40102, HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     EMPTY_REFRESH_TOKEN_ERROR(40103, HttpStatus.UNAUTHORIZED, "해당 유저의 리프레시 토큰이 존재하지 않습니다."),
+    INVALID_TOKEN_PREFIX_ERROR(40104, HttpStatus.UNAUTHORIZED, "토큰의 prefix가 올바르지 않습니다"),
+
+    //403
     OAUTH_SERVER_ERROR(40300, HttpStatus.BAD_GATEWAY, "OAuth 서버 에러입니다.");
 
     private final int code;

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -10,8 +10,8 @@ public enum ErrorCode {
     LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
     INVALID_ACCESS_TOKEN_ERROR(40102, HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
-    OAUTH_SERVER_ERROR(40300, HttpStatus.BAD_GATEWAY, "OAuth 서버 에러입니다. ");
-
+    EMPTY_REFRESH_TOKEN_ERROR(40103, HttpStatus.UNAUTHORIZED, "해당 유저의 리프레시 토큰이 존재하지 않습니다."),
+    OAUTH_SERVER_ERROR(40300, HttpStatus.BAD_GATEWAY, "OAuth 서버 에러입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -8,8 +8,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
     LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
-    INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    INVALID_REFRESH_TOKEN_ERROR(40101, HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_ACCESS_TOKEN_ERROR(40102, HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     OAUTH_SERVER_ERROR(40300, HttpStatus.BAD_GATEWAY, "OAuth 서버 에러입니다. ");
+
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/gdsc/comunity/exception/ErrorCode.java
+++ b/src/main/java/gdsc/comunity/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package gdsc.comunity.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    LOGIN_REQUIRED(40100, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/gdsc/comunity/interceptor/UserIdArgumentResolver.java
+++ b/src/main/java/gdsc/comunity/interceptor/UserIdArgumentResolver.java
@@ -1,0 +1,34 @@
+package gdsc.comunity.interceptor;
+
+import gdsc.comunity.annotation.UserId;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    //parameter객체의 타입을 확인하는 메소드
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(UserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Object userIdObj = webRequest.getAttribute("userId", NativeWebRequest.SCOPE_REQUEST);
+        if (userIdObj == null) {
+            //TODO: 예외 처리
+        }
+        return Long.parseLong((String) userIdObj);
+    }
+}

--- a/src/main/java/gdsc/comunity/interceptor/UserIdArgumentResolver.java
+++ b/src/main/java/gdsc/comunity/interceptor/UserIdArgumentResolver.java
@@ -1,6 +1,8 @@
 package gdsc.comunity.interceptor;
 
 import gdsc.comunity.annotation.UserId;
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -27,7 +29,7 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
     ) {
         Object userIdObj = webRequest.getAttribute("userId", NativeWebRequest.SCOPE_REQUEST);
         if (userIdObj == null) {
-            //TODO: 예외 처리
+            throw new CustomException(ErrorCode.LOGIN_REQUIRED);
         }
         return Long.parseLong((String) userIdObj);
     }

--- a/src/main/java/gdsc/comunity/interceptor/UserIdInterceptor.java
+++ b/src/main/java/gdsc/comunity/interceptor/UserIdInterceptor.java
@@ -1,0 +1,27 @@
+package gdsc.comunity.interceptor;
+
+import gdsc.comunity.security.info.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+public class UserIdInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) throws Exception {
+        UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("UserIdInterceptor is running... userId: {}", userPrincipal.getId());
+        //request객체에 UserId 값 추가
+        request.setAttribute("userId", userPrincipal.getId());
+
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+}

--- a/src/main/java/gdsc/comunity/interceptor/UserIdInterceptor.java
+++ b/src/main/java/gdsc/comunity/interceptor/UserIdInterceptor.java
@@ -18,7 +18,7 @@ public class UserIdInterceptor implements HandlerInterceptor {
             Object handler
     ) throws Exception {
         UserPrincipal userPrincipal = (UserPrincipal) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        log.info("UserIdInterceptor is running... userId: {}", userPrincipal.getId());
+
         //request객체에 UserId 값 추가
         request.setAttribute("userId", userPrincipal.getId());
 

--- a/src/main/java/gdsc/comunity/interceptor/config/WebMvcConfig.java
+++ b/src/main/java/gdsc/comunity/interceptor/config/WebMvcConfig.java
@@ -1,0 +1,32 @@
+package gdsc.comunity.interceptor.config;
+
+import gdsc.comunity.interceptor.UserIdArgumentResolver;
+import gdsc.comunity.interceptor.UserIdInterceptor;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final UserIdArgumentResolver userIdArgumentResolver;
+    private final UserIdInterceptor userIdInterceptor;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        WebMvcConfigurer.super.addArgumentResolvers(resolvers);
+        resolvers.add(this.userIdArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(userIdInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/");
+    }
+}

--- a/src/main/java/gdsc/comunity/interceptor/config/WebMvcConfig.java
+++ b/src/main/java/gdsc/comunity/interceptor/config/WebMvcConfig.java
@@ -27,6 +27,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(userIdInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/");
+                .excludePathPatterns("/api/login",
+                        "/api/auth/register",
+                        "/oauth/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**");
     }
 }

--- a/src/main/java/gdsc/comunity/repository/user/UserRepository.java
+++ b/src/main/java/gdsc/comunity/repository/user/UserRepository.java
@@ -1,7 +1,9 @@
 package gdsc.comunity.repository.user;
 
 import gdsc.comunity.entity.user.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
@@ -55,25 +55,20 @@ public class SecurityConfig {
                 .logout(logout -> logout
                         .logoutUrl("/api/auth/logout")
                         .addLogoutHandler((request, response, authentication) -> {
-                            log.info("logout handler is running...");
-
                             //1. authentication에서 userId 추출
                             Long userId = ((UserPrincipal) authentication.getPrincipal()).getId();
-                            log.info("userId : {}", userId);
+
                             //2. 해당 userId로 redis에서 refresh token 조회 후 삭제
                             Optional<RefreshToken> refreshTokenOP = refreshTokenRepository.findByUserId(userId);
                             if (refreshTokenOP.isEmpty()) {
-                                log.info("refresh token is not found");
                                 throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
                             }
                             refreshTokenRepository.delete(refreshTokenOP.get());
-                            log.info("logout handler is done...");
                         })
                         .logoutSuccessHandler((request, response, authentication) -> {
                             response.setStatus(HttpStatus.OK.value());
                             response.addHeader("message", "logout success");
                             }
-
                         )
                 )
 

--- a/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                             //2. 해당 userId로 redis에서 refresh token 조회 후 삭제
                             Optional<RefreshToken> refreshTokenOP = refreshTokenRepository.findByUserId(userId);
                             if (refreshTokenOP.isEmpty()) {
-                                throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
+                                throw new CustomException(ErrorCode.EMPTY_REFRESH_TOKEN_ERROR);
                             }
                             refreshTokenRepository.delete(refreshTokenOP.get());
                         })

--- a/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package gdsc.comunity.security.config;
+
+import gdsc.comunity.security.filter.JwtAuthenticationFilter;
+import gdsc.comunity.security.filter.JwtExceptionFilter;
+import gdsc.comunity.security.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm ->
+                        sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+
+                .authorizeHttpRequests(registry ->
+                        registry
+                                .requestMatchers("/api/login", "/api/auth/register").permitAll()
+                                .requestMatchers("/oauth/**").permitAll()
+                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+
+//                .logout(logout -> logout
+//                        .logoutUrl("/api/auth/logout")
+//                        .addLogoutHandler()
+//                        .logoutSuccessHandler()
+//                )
+
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint((request, response, authException) -> response.setStatus(HttpServletResponse.SC_UNAUTHORIZED))
+                        .accessDeniedHandler((request, response, accessDeniedException) -> response.setStatus(HttpServletResponse.SC_FORBIDDEN))
+                )
+
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtProvider),
+                        LogoutFilter.class
+                )
+                .addFilterBefore(
+                        new JwtExceptionFilter(),
+                        JwtAuthenticationFilter.class
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         registry
                                 .requestMatchers("/api/login", "/api/auth/register").permitAll()
                                 .requestMatchers("/oauth/**").permitAll()
+                                .requestMatchers("/api/auth/refresh").permitAll()
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package gdsc.comunity.security.filter;
 
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
 import gdsc.comunity.security.info.UserPrincipal;
 import gdsc.comunity.security.jwt.JwtProvider;
 import io.jsonwebtoken.Claims;
@@ -30,8 +32,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String accessToken = bearerToken.substring(7);
-
-        Claims claims = jwtProvider.validateToken(accessToken);
+        Claims claims;
+        try {
+            claims = jwtProvider.validateToken(accessToken);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN_ERROR);
+        }
         if (claims.get("isAccessToken", Boolean.class)) {
             //Claim은 String, Integer, Boolean만 저장 가능하다.
             String userIdStr = claims.get("userId", String.class);

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -1,14 +1,21 @@
 package gdsc.comunity.security.filter;
 
+import gdsc.comunity.security.info.UserPrincipal;
 import gdsc.comunity.security.jwt.JwtProvider;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
@@ -16,7 +23,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        // TODO : JWT validate해서 authentication을 securityContext에 넣기
+        log.info("JwtAuthenticationFilter is running...");
+
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+        }
+        String accessToken = bearerToken.substring(7);
+
+        Claims claims = jwtProvider.validateToken(accessToken);
+        log.info("claims: {}", claims);
+        if (claims.get("isAccessToken", Boolean.class)) {
+            Long userId = claims.get("userId", Long.class);
+            UserPrincipal userPrincipal = new UserPrincipal(userId);
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                    userPrincipal, null, null); // 권한은 없음
+
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authenticationToken);
+            SecurityContextHolder.setContext(context);
+            log.info("UserPrincipal: {}", userPrincipal);
+        }
+
         filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -27,7 +27,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            log.info("BearerToken is null or does not start with 'Bearer '");
+            log.info("bearerToken : {}", bearerToken);
             filterChain.doFilter(request, response);
+            return;
         }
         String accessToken = bearerToken.substring(7);
 

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -34,7 +34,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Claims claims = jwtProvider.validateToken(accessToken);
         log.info("claims: {}", claims);
         if (claims.get("isAccessToken", Boolean.class)) {
-            Long userId = claims.get("userId", Long.class);
+            log.info("isAccessToken: {}", claims.get("isAccessToken", Boolean.class));
+            log.info("userId: {}", claims.get("userId", String.class));
+
+            //Claim은 String, Integer, Boolean 저장 가능?
+            String userIdStr = claims.get("userId", String.class);
+            Long userId = Long.parseLong(userIdStr);
+
             UserPrincipal userPrincipal = new UserPrincipal(userId);
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
                     userPrincipal, null, null); // 권한은 없음

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -23,24 +23,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        log.info("JwtAuthenticationFilter is running...");
-
         String bearerToken = request.getHeader("Authorization");
         if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-            log.info("BearerToken is null or does not start with 'Bearer '");
-            log.info("bearerToken : {}", bearerToken);
             filterChain.doFilter(request, response);
             return;
         }
+
         String accessToken = bearerToken.substring(7);
 
         Claims claims = jwtProvider.validateToken(accessToken);
-        log.info("claims: {}", claims);
         if (claims.get("isAccessToken", Boolean.class)) {
-            log.info("isAccessToken: {}", claims.get("isAccessToken", Boolean.class));
-            log.info("userId: {}", claims.get("userId", String.class));
-
-            //Claim은 String, Integer, Boolean 저장 가능?
+            //Claim은 String, Integer, Boolean만 저장 가능하다.
             String userIdStr = claims.get("userId", String.class);
             Long userId = Long.parseLong(userIdStr);
 
@@ -51,7 +44,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(authenticationToken);
             SecurityContextHolder.setContext(context);
-            log.info("UserPrincipal: {}", userPrincipal);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,22 @@
+package gdsc.comunity.security.filter;
+
+import gdsc.comunity.security.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        // TODO : JWT validate해서 authentication을 securityContext에 넣기
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,21 @@
+package gdsc.comunity.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception e) {
+            //TODO : Exception 처리
+//            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
@@ -5,8 +5,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 public class JwtExceptionFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -15,7 +17,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (Exception e) {
             //TODO : Exception 처리
-//            filterChain.doFilter(request, response);
+            log.error("Exception occurred : {}", e.getMessage());
         }
     }
 }

--- a/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtExceptionFilter.java
@@ -1,5 +1,7 @@
 package gdsc.comunity.security.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gdsc.comunity.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,9 +17,21 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
+        } catch (CustomException e) {
+            //fixme : 예외처리 공통 Response 사용해서 처리하기
+            ObjectMapper om = new ObjectMapper();
+            response.setContentType("application/json; charset=utf-8");
+            response.setStatus(e.getErrorCode().getStatus().value());
+            String responseBody = om.writeValueAsString(e.getErrorCode().getMessage());
+            response.getWriter().println(responseBody);
+
+            log.error("CustomException occurred : {}", e.getMessage());
+            log.error("CustomException occurred : {}", e.getStackTrace());
+
         } catch (Exception e) {
-            //TODO : Exception 처리
+            //fixme : 예외처리 공통 Response 사용해서 처리하기
             log.error("Exception occurred : {}", e.getMessage());
+            log.error("Exception occurred : {}", e.getStackTrace());
         }
     }
 }

--- a/src/main/java/gdsc/comunity/security/info/UserPrincipal.java
+++ b/src/main/java/gdsc/comunity/security/info/UserPrincipal.java
@@ -1,0 +1,51 @@
+package gdsc.comunity.security.info;
+
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class UserPrincipal implements UserDetails {
+    private final Long id;
+
+    /**
+     * 아래 함수는 사용하지 않음. 임시로 null 또는 true를 반환한다.
+     */
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
+++ b/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
@@ -1,0 +1,39 @@
+package gdsc.comunity.security.jwt;
+
+import gdsc.comunity.dto.JwtTokensDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+
+    public JwtTokensDto generateTokens(Long userId) {
+        String accessToken = generateToken(userId, true);
+        String refreshToken = generateToken(userId, false);
+        return JwtTokensDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    private String generateToken(Long userId, boolean isAccessToken){
+        long expireTime = isAccessToken ? JwtVO.ACCESS_TOKEN_EXPIRATION_TIME : JwtVO.REFRESH_TOKEN_EXPIRATION_TIME;
+        Date expireDate = new Date(System.currentTimeMillis() + expireTime);
+        return Jwts.builder()
+                .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
+                .claim("userId",userId.toString())
+                .claim("isAccessToken", isAccessToken)
+                .setExpiration(expireDate)
+                .compact();
+    }
+
+    public Claims validateToken(String token) {
+        return null; //TODO: token 검증
+    }
+}

--- a/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
+++ b/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
@@ -23,17 +23,24 @@ public class JwtProvider {
     }
 
     private String generateToken(Long userId, boolean isAccessToken){
+        Claims claims = Jwts.claims();
+        claims.put("userId", userId.toString());
+        claims.put("isAccessToken", isAccessToken);
+
         long expireTime = isAccessToken ? JwtVO.ACCESS_TOKEN_EXPIRATION_TIME : JwtVO.REFRESH_TOKEN_EXPIRATION_TIME;
         Date expireDate = new Date(System.currentTimeMillis() + expireTime);
+
         return Jwts.builder()
                 .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
-                .claim("userId",userId.toString())
-                .claim("isAccessToken", isAccessToken)
+                .setClaims(claims)
                 .setExpiration(expireDate)
                 .compact();
     }
 
     public Claims validateToken(String token) {
-        return null; //TODO: token 검증
+        return Jwts.parser()
+                .setSigningKey(SECRET_KEY)
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
+++ b/src/main/java/gdsc/comunity/security/jwt/JwtProvider.java
@@ -25,7 +25,7 @@ public class JwtProvider {
 
     private String generateRefreshToken() {
         Claims claims = Jwts.claims();
-        claims.put("isAccessToken", true);
+        claims.put("isAccessToken", false);
 
         Date expireDate = new Date(System.currentTimeMillis() + JwtVO.REFRESH_TOKEN_EXPIRATION_TIME);
 

--- a/src/main/java/gdsc/comunity/security/jwt/JwtVO.java
+++ b/src/main/java/gdsc/comunity/security/jwt/JwtVO.java
@@ -1,0 +1,9 @@
+package gdsc.comunity.security.jwt;
+
+public interface JwtVO {
+    public static final int ACCESS_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60; // 1hour
+    public static final int REFRESH_TOKEN_EXPIRATION_TIME = 1000 * 60 * 60 * 24 * 7; // 1week
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String HEADER = "Authorization";
+
+}

--- a/src/main/java/gdsc/comunity/security/jwt/RefreshToken.java
+++ b/src/main/java/gdsc/comunity/security/jwt/RefreshToken.java
@@ -15,9 +15,12 @@ import org.springframework.data.redis.core.index.Indexed;
 public class RefreshToken {
     @Id
     private String refreshToken;
+
+    @Indexed
     private Long userId;
+
     @Builder
-    public RefreshToken(String refreshToken, Long userId) {
+    private RefreshToken(String refreshToken, Long userId) {
         this.refreshToken = refreshToken;
         this.userId = userId;
     }

--- a/src/main/java/gdsc/comunity/security/jwt/RefreshToken.java
+++ b/src/main/java/gdsc/comunity/security/jwt/RefreshToken.java
@@ -1,0 +1,24 @@
+package gdsc.comunity.security.jwt;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = JwtVO.REFRESH_TOKEN_EXPIRATION_TIME / 1000)
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private Long userId;
+    @Builder
+    public RefreshToken(String refreshToken, Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+}

--- a/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
@@ -5,6 +5,5 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
-
     Optional<RefreshToken> findByUserId(Long userId);
 }

--- a/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package gdsc.comunity.security.jwt;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken,Long> {
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/gdsc/comunity/security/jwt/RefreshTokenRepository.java
@@ -3,6 +3,8 @@ package gdsc.comunity.security.jwt;
 import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken,Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    Optional<RefreshToken> findByUserId(Long userId);
 }

--- a/src/main/java/gdsc/comunity/security/service/UserPrincipalService.java
+++ b/src/main/java/gdsc/comunity/security/service/UserPrincipalService.java
@@ -1,0 +1,24 @@
+package gdsc.comunity.security.service;
+
+import gdsc.comunity.entity.user.User;
+import gdsc.comunity.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserPrincipalService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    /**
+     * OAuth2 로그인만 구현해놓은 상태에서 해당 로직을 사용하지 않음.
+     * 따라서 임시로 null을 반환한다.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return null;
+    }
+}

--- a/src/main/java/gdsc/comunity/service/AuthService.java
+++ b/src/main/java/gdsc/comunity/service/AuthService.java
@@ -1,0 +1,52 @@
+package gdsc.comunity.service;
+
+import gdsc.comunity.dto.JwtTokensDto;
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
+import gdsc.comunity.security.jwt.JwtProvider;
+import gdsc.comunity.security.jwt.RefreshToken;
+import gdsc.comunity.security.jwt.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    public void validateRefreshToken(String refreshToken) {
+        log.info("validateRefreshToken method start, refreshToken : {}", refreshToken);
+        Claims claims = jwtProvider.validateToken(refreshToken);
+        boolean isAccessToken = claims.get("isAccessToken", Boolean.class);
+        if (isAccessToken) {
+            throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
+        }
+        log.info("validateRefreshToken method end");
+    }
+
+    public JwtTokensDto refreshNewTokens(String refreshToken) {
+        log.info("refreshNewTokens method start, refreshToken : {}", refreshToken);
+        //1. redis에서 해당 refresh token 조회하고 userId 얻기
+        RefreshToken refreshTokenFromRepo = refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR));
+        Long userId = refreshTokenFromRepo.getUserId();
+
+        //2. 해당 토큰 삭제
+        refreshTokenRepository.delete(refreshTokenFromRepo);
+
+        //3. 새롭게 생성하고 반환
+        JwtTokensDto jwtTokensDto = jwtProvider.generateTokens(userId);
+        saveRefreshToken(userId, jwtTokensDto.refreshToken());
+        return jwtTokensDto;
+    }
+
+    private void saveRefreshToken(Long userId, String refreshToken) {
+        refreshTokenRepository.save(RefreshToken.builder()
+                .userId(userId)
+                .refreshToken(refreshToken)
+                .build());
+    }
+}

--- a/src/main/java/gdsc/comunity/service/AuthService.java
+++ b/src/main/java/gdsc/comunity/service/AuthService.java
@@ -18,17 +18,15 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     public void validateRefreshToken(String refreshToken) {
-        log.info("validateRefreshToken method start, refreshToken : {}", refreshToken);
         Claims claims = jwtProvider.validateToken(refreshToken);
         boolean isAccessToken = claims.get("isAccessToken", Boolean.class);
+
         if (isAccessToken) {
             throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR);
         }
-        log.info("validateRefreshToken method end");
     }
 
     public JwtTokensDto refreshNewTokens(String refreshToken) {
-        log.info("refreshNewTokens method start, refreshToken : {}", refreshToken);
         //1. redis에서 해당 refresh token 조회하고 userId 얻기
         RefreshToken refreshTokenFromRepo = refreshTokenRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN_ERROR));

--- a/src/main/java/gdsc/comunity/service/OAuthGoogleService.java
+++ b/src/main/java/gdsc/comunity/service/OAuthGoogleService.java
@@ -1,5 +1,6 @@
 package gdsc.comunity.service;
 
+import gdsc.comunity.dto.GoogleUserInfo;
 import gdsc.comunity.dto.JwtTokensDto;
 import gdsc.comunity.entity.user.Provider;
 import gdsc.comunity.entity.user.User;
@@ -8,7 +9,6 @@ import gdsc.comunity.security.jwt.JwtProvider;
 import gdsc.comunity.security.jwt.RefreshToken;
 import gdsc.comunity.security.jwt.RefreshTokenRepository;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class OAuthService {
+public class OAuthGoogleService {
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
     private String CLIENT_ID;
 
@@ -61,7 +61,7 @@ public class OAuthService {
                 .retrieve()
                 .toEntity(Map.class)
                 .block().getBody();
-
+        log.info("responseBody : {}", responseBody);
         log.info("getAccessToken method end soon, code : {}", code);
         return responseBody.get("access_token");
     }
@@ -81,6 +81,7 @@ public class OAuthService {
                 .toEntity(Map.class)
                 .block().getBody();
 
+        log.info("responseBody : {}", responseBody);
         log.info("getUserInfoByAccessToken method end soon, accessTokenByOAuth : {}", accessTokenByOAuth);
         return responseBody;
     }

--- a/src/main/java/gdsc/comunity/service/OAuthGoogleService.java
+++ b/src/main/java/gdsc/comunity/service/OAuthGoogleService.java
@@ -45,8 +45,6 @@ public class OAuthGoogleService {
     @Transactional
     public String getAccessToken(String code) {
         Map<String, String> responseBody;
-        // OAuth 토큰 요청 보내기
-        log.info("getAccessToken method start, code : {}", code);
 
         responseBody = webClientForGetAccessToken.post()
                 .uri("token")
@@ -61,15 +59,12 @@ public class OAuthGoogleService {
                 .retrieve()
                 .toEntity(Map.class)
                 .block().getBody();
-        log.info("responseBody : {}", responseBody);
-        log.info("getAccessToken method end soon, code : {}", code);
+
         return responseBody.get("access_token");
     }
 
     public Map<String, String> getUserInfoByAccessToken(String accessTokenByOAuth) {
         Map<String, String> responseBody;
-        // OAuth 토큰으로 유저 정보 요청 보내기
-        log.info("getUserInfoByAccessToken method start, accessTokenByOAuth : {}", accessTokenByOAuth);
 
         responseBody = webClientForGetUserInfo.get()
                 .uri("")
@@ -81,8 +76,6 @@ public class OAuthGoogleService {
                 .toEntity(Map.class)
                 .block().getBody();
 
-        log.info("responseBody : {}", responseBody);
-        log.info("getUserInfoByAccessToken method end soon, accessTokenByOAuth : {}", accessTokenByOAuth);
         return responseBody;
     }
 

--- a/src/main/java/gdsc/comunity/service/OAuthService.java
+++ b/src/main/java/gdsc/comunity/service/OAuthService.java
@@ -1,0 +1,103 @@
+package gdsc.comunity.service;
+
+import gdsc.comunity.dto.JwtTokensDto;
+import gdsc.comunity.entity.user.Provider;
+import gdsc.comunity.entity.user.User;
+import gdsc.comunity.repository.user.UserRepository;
+import gdsc.comunity.security.jwt.JwtProvider;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OAuthService {
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String CLIENT_SECRET;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String REDIRECT_URI;
+    private final JwtProvider jwtProvider;
+    private final WebClient webClientForGetAccessToken = WebClient.builder()
+            .baseUrl("https://oauth2.googleapis.com")
+            .build();
+    private final WebClient webClientForGetUserInfo = WebClient.builder()
+            .baseUrl("https://www.googleapis.com/userinfo/v2/me")
+            .build();
+    private final UserRepository userRepository;
+
+    @Transactional
+    public String getAccessToken(String code) {
+        Map<String, String> responseBody;
+        // OAuth 토큰 요청 보내기
+        log.info("getAccessToken method start, code : {}", code);
+
+        responseBody = webClientForGetAccessToken.post()
+                .uri("token")
+                .headers(httpHeaders -> {
+                    httpHeaders.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+                })
+                .body(BodyInserters.fromFormData("code", code)
+                        .with("client_id", CLIENT_ID)
+                        .with("client_secret", CLIENT_SECRET)
+                        .with("redirect_uri", REDIRECT_URI)
+                        .with("grant_type", "authorization_code"))
+                .retrieve()
+                .toEntity(Map.class)
+                .block().getBody();
+
+        log.info("getAccessToken method end soon, code : {}", code);
+        return responseBody.get("access_token");
+    }
+
+    public Map<String, String> getUserInfoByAccessToken(String accessTokenByOAuth) {
+        Map<String, String> responseBody;
+        // OAuth 토큰으로 유저 정보 요청 보내기
+        log.info("getUserInfoByAccessToken method start, accessTokenByOAuth : {}", accessTokenByOAuth);
+
+        responseBody = webClientForGetUserInfo.get()
+                .uri("")
+                .headers(httpHeaders -> {
+                    httpHeaders.set("Authorization", "Bearer " + accessTokenByOAuth);
+                })
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .toEntity(Map.class)
+                .block().getBody();
+
+        log.info("getUserInfoByAccessToken method end soon, accessTokenByOAuth : {}", accessTokenByOAuth);
+        return responseBody;
+    }
+
+    @Transactional
+    public JwtTokensDto loginOrRegister(Map<String, String> userInfo) {
+        // 유저가 존재하는지 확인
+        String email = userInfo.get("email");
+        Optional<User> userOP= userRepository.findByEmail(email);
+        if (userOP.isEmpty()) {
+            // 유저가 존재하지 않으면 회원가입
+            User user = User.builder()
+                    .providerId(userInfo.get("id"))
+                    .profileImageUrl(userInfo.get("picture"))
+                    .provider(Provider.GOOGLE)
+                    .email(email)
+                    .build();
+            User savedUser = userRepository.save(user);
+            return jwtProvider.generateTokens(savedUser.getId());
+        }
+        return jwtProvider.generateTokens(userOP.get().getId());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,12 @@ spring:
     password: ""
     driver-class-name: org.h2.Driver
 
+  # redis 설정
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
   jpa:
     hibernate:
       ddl-auto: create
@@ -19,7 +25,21 @@ spring:
       enabled: true
       path: /h2-console
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+
 logging.level:
   org.hibernate:
     orm.jdbc.bind: trace
     SQL: debug
+
+jwt:
+  secret: "${JWT_SECRET}"
+
+

--- a/src/test/java/gdsc/comunity/security/jwt/RefreshTokenRepositoryTest.java
+++ b/src/test/java/gdsc/comunity/security/jwt/RefreshTokenRepositoryTest.java
@@ -1,0 +1,43 @@
+package gdsc.comunity.security.jwt;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@ActiveProfiles("dev")
+@SpringBootTest(webEnvironment = WebEnvironment.MOCK)
+class RefreshTokenRepositoryTest {
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Test
+    @DisplayName("userId로 RefreshToken 조회 테스트")
+    void test() {
+        //given
+        String refreshTokenStr = "test";
+        Long userId = 1L;
+        RefreshToken refreshToken = RefreshToken.builder()
+                .refreshToken(refreshTokenStr)
+                .userId(userId)
+                .build();
+        refreshTokenRepository.save(refreshToken);
+
+        //when
+        Optional<RefreshToken> findRefreshToken = refreshTokenRepository.findByUserId(userId);
+
+        //then
+        assertTrue(findRefreshToken.isPresent());
+        assertEquals(findRefreshToken.get().getRefreshToken(), refreshTokenStr);
+    }
+}


### PR DESCRIPTION
## 구현 기능
- 구글 로그인 & 자동 회원가입
- 로그아웃
- access token 재발급
- refresh token redis 저장

> 로그아웃시 현재는 refresh token을 삭제하는 것으로 구현했습니다. 관련 논의가 필요합니다.
> 현재 refresh token을 저장하는 redis는 localhost 기준으로 설정했습니다. 추후 메시징 큐를 사용할 때, 다시 설정해야 합니다.
> CustomException과 ErrorCode를 활용한 에러 코드를 작성했습니다. 확인하시고 문제점이 있으면 논의하면 좋겠습니다.
