### PR TITLE
STOMP Authorization, Argument Resolver

### DIFF
--- a/src/main/java/gdsc/comunity/configuration/WebMvcConfig.java
+++ b/src/main/java/gdsc/comunity/configuration/WebMvcConfig.java
@@ -1,4 +1,4 @@
-package gdsc.comunity.interceptor.config;
+package gdsc.comunity.configuration;
 
 import gdsc.comunity.interceptor.UserIdArgumentResolver;
 import gdsc.comunity.interceptor.UserIdInterceptor;

--- a/src/main/java/gdsc/comunity/configuration/WebSocketConfigurer.java
+++ b/src/main/java/gdsc/comunity/configuration/WebSocketConfigurer.java
@@ -1,14 +1,23 @@
 package gdsc.comunity.configuration;
 
+import gdsc.comunity.interceptor.SocketUserIdArgumentResolver;
+import gdsc.comunity.interceptor.SocketUserIdInterceptor;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
+    private final SocketUserIdInterceptor socketUserIdInterceptor;
+    private final SocketUserIdArgumentResolver socketUserIdArgumentResolver;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -22,4 +31,13 @@ public class WebSocketConfigurer implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOrigins("*");
     }
 
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(socketUserIdArgumentResolver);
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(socketUserIdInterceptor);
+    }
 }

--- a/src/main/java/gdsc/comunity/interceptor/SocketUserIdArgumentResolver.java
+++ b/src/main/java/gdsc/comunity/interceptor/SocketUserIdArgumentResolver.java
@@ -1,0 +1,34 @@
+package gdsc.comunity.interceptor;
+
+import gdsc.comunity.annotation.UserId;
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
+import gdsc.comunity.security.jwt.JwtProvider;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SocketUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(Long.class)
+                && parameter.hasParameterAnnotation(UserId.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            Message<?> message
+    ) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        Object userIdObj = accessor.getSessionAttributes().get("userId");
+        return Long.parseLong(userIdObj.toString());
+    }
+}

--- a/src/main/java/gdsc/comunity/interceptor/SocketUserIdInterceptor.java
+++ b/src/main/java/gdsc/comunity/interceptor/SocketUserIdInterceptor.java
@@ -1,0 +1,61 @@
+package gdsc.comunity.interceptor;
+
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
+import gdsc.comunity.security.info.UserPrincipal;
+import gdsc.comunity.security.jwt.JwtProvider;
+import gdsc.comunity.security.jwt.JwtVO;
+import gdsc.comunity.util.HeaderUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import io.jsonwebtoken.Claims;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SocketUserIdInterceptor implements ChannelInterceptor {
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public Message<?> preSend(
+            Message<?> message,
+            MessageChannel channel
+    ) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            // STOMP Header에서 토큰 추출
+            String accessToken = HeaderUtil.extractToken(accessor, JwtVO.HEADER, JwtVO.TOKEN_PREFIX);
+            log.info("accessToken: " + accessToken);
+
+            // 토큰 검증
+            Claims claims = jwtProvider.validateToken(accessToken);
+            Long userId = null;
+
+            if (claims.get("isAccessToken", Boolean.class)) {
+                //Claim은 String, Integer, Boolean만 저장 가능하다.
+                String userIdStr = claims.get("userId", String.class);
+
+                userId = Long.parseLong(userIdStr);
+                accessor.getSessionAttributes().put("userId", userId);
+            }
+            else {
+                throw new CustomException(ErrorCode.INVALID_ACCESS_TOKEN_ERROR);
+            }
+        }
+        // 메시지 반환
+        return message;
+    }
+}

--- a/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
+++ b/src/main/java/gdsc/comunity/security/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/login", "/api/auth/register").permitAll()
                                 .requestMatchers("/oauth/**").permitAll()
                                 .requestMatchers("/api/auth/refresh").permitAll()
+                                .requestMatchers("/stomp", "/api/pub/**", "/api/sub/**").permitAll()
                                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/gdsc/comunity/security/filter/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import gdsc.comunity.exception.ErrorCode;
 import gdsc.comunity.security.info.UserPrincipal;
 import gdsc.comunity.security.jwt.JwtProvider;
 import gdsc.comunity.security.jwt.JwtVO;
+import gdsc.comunity.util.HeaderUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,18 +27,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        String bearerToken = request.getHeader(JwtVO.HEADER);
+        String accessToken = HeaderUtil.extractToken(request, JwtVO.HEADER, JwtVO.TOKEN_PREFIX);
 
-        if (bearerToken == null) {
+        if (accessToken == null) {
             filterChain.doFilter(request, response);
             return;
         }
 
-        if (!bearerToken.startsWith(JwtVO.TOKEN_PREFIX)) {
-            throw new CustomException(ErrorCode.INVALID_TOKEN_PREFIX_ERROR);
-        }
-
-        String accessToken = bearerToken.substring(7);
         Claims claims;
         try {
             claims = jwtProvider.validateToken(accessToken);

--- a/src/main/java/gdsc/comunity/util/HeaderUtil.java
+++ b/src/main/java/gdsc/comunity/util/HeaderUtil.java
@@ -1,0 +1,33 @@
+package gdsc.comunity.util;
+
+import gdsc.comunity.exception.CustomException;
+import gdsc.comunity.exception.ErrorCode;
+import gdsc.comunity.security.jwt.JwtVO;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.util.StringUtils;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+
+public class HeaderUtil {
+    public static String extractToken(HttpServletRequest request, String header, String tokenPrefix) {
+        String bearerToken = request.getHeader(JwtVO.HEADER);
+        if (bearerToken == null) {
+            return null;
+        }
+
+        if (!bearerToken.startsWith(JwtVO.TOKEN_PREFIX)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN_PREFIX_ERROR);
+        }
+
+        return bearerToken.substring(7);
+    }
+
+    public static String extractToken(StompHeaderAccessor request, String header, String tokenPrefix) {
+        String bearerToken = request.getFirstNativeHeader(header);
+
+        if (!StringUtils.hasText(bearerToken) || !bearerToken.startsWith(tokenPrefix)) {
+            throw new CustomException(ErrorCode.INVALID_TOKEN_PREFIX_ERROR);
+        }
+
+        return bearerToken.substring(tokenPrefix.length());
+    }
+}


### PR DESCRIPTION
## 구현 기능
- STOMP에서 CONNECT 요청시 JWT Token 파싱해서 인증 정보 세션에 저장하는 기능
- CONNECT를 제외한 다른 요청시, 세션에 있는 인증정보로 UserId 넣어주는 기능

> 현재 CONNECT 요청시에만 JWT를 파싱하고, 이후에는 JWT를 파싱하지 않습니다. 매 요청마다 JWT가 필요하다고 판단이 들면, 추후에 수정하면 될 것 같습니다.
